### PR TITLE
Performance improvement

### DIFF
--- a/Source/Delta.cs
+++ b/Source/Delta.cs
@@ -35,7 +35,7 @@ namespace Fossil
 			for (i = 0; i < landmark.Length; i++) landmark[i] = -1;
 			int hv;
 			RollingHash h = new RollingHash();
-			for (i = 0; i < lenSrc-NHASH; i += NHASH) {
+			for (i = lenSrc - lenSrc % NHASH - NHASH; i >= 0; i -= NHASH)
 				h.Init(origin, i);
 				hv = (int) (h.Value() % nHash);
 				collide[i/NHASH] = landmark[hv];
@@ -75,9 +75,19 @@ namespace Fossil
 						int j, k, x, y;
 						int sz;
 
+						
+						iSrc = iBlock*NHASH;
+
+						//if iSrc is insied the best match region we can skip
+						// as this would lead to the same match 
+						if (bestCnt > 0 && iSrc > bestOfst && iSrc < (bestOfst + bestCnt))
+						{
+							iBlock = collide[iBlock];
+							continue;
+						}
+
 						// Beginning at iSrc, match forwards as far as we can.
 						// j counts the number of characters that match.
-						iSrc = iBlock*NHASH;
 						for (j = 0, x = iSrc, y = _base+i; x < lenSrc && y < lenOut; j++, x++, y++) {
 							if (origin[x] != target[y]) break;
 						}

--- a/Source/Delta.cs
+++ b/Source/Delta.cs
@@ -78,7 +78,7 @@ namespace Fossil
 						
 						iSrc = iBlock*NHASH;
 
-						//if iSrc is insied the best match region we can skip
+						//if iSrc is inside the best match region we can skip
 						// as this would lead to the same match 
 						if (bestCnt > 0 && iSrc > bestOfst && iSrc < (bestOfst + bestCnt))
 						{


### PR DESCRIPTION
This small change reverses the origin loop order. By doing so landmarks become the first appearance of each hash, and collides are on forward ( left to right ) order. 
This greatly improves performance, especially for larger inputs with small changes. 
The original code, when matching a huge section would find the landmark, which would be further to the right, and cycle the collisions from left to right, getting a bigger match at every pass. With this modification most times the code can find the biggest match at the first pass, and skip checking if the other collisions are inside the already found match.